### PR TITLE
Support for existing asset configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -15,6 +17,11 @@ pub struct Creator {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ExistingAsset {
+    pub id: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub asset_dir: String,
     pub write_dir: String,
@@ -22,4 +29,6 @@ pub struct Config {
     pub output_name: Option<String>,
     pub typescript: Option<bool>,
     pub luau: Option<bool>,
+
+    pub existing: Option<HashMap<String, ExistingAsset>>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
         toml::from_str(&file_contents).context("Failed to parse config")
     }?;
 
-    let mut state = State::new(args, &config)
+    let mut state = State::new(args, config)
         .await
         .context("Failed to create state")?;
 
@@ -163,6 +163,19 @@ async fn main() -> anyhow::Result<()> {
         .asset_dir
         .to_str()
         .context("Failed to convert asset directory to string")?;
+
+    state
+        .new_lockfile
+        .entries
+        .extend(state.existing.into_iter().map(|(path, asset)| {
+            (
+                path,
+                FileEntry {
+                    hash: "".to_string(),
+                    asset_id: asset.id,
+                },
+            )
+        }));
 
     let lua_filename = format!("{}.{}", state.output_name, state.lua_extension);
     let lua_output = generate_lua(&state.new_lockfile, asset_dir_str);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,13 +1,12 @@
-use std::{env, path::PathBuf};
-
 use crate::{
     args::Args,
-    config::{Config, CreatorType},
+    config::{Config, CreatorType, ExistingAsset},
     LockFile,
 };
 use anyhow::Context;
 use rbxcloud::rbx::v1::assets::{AssetCreator, AssetGroupCreator, AssetUserCreator};
 use resvg::usvg::fontdb::Database;
+use std::{collections::HashMap, env, path::PathBuf};
 use tokio::fs::{create_dir_all, read_to_string};
 
 fn add_trailing_slash(path: &str) -> String {
@@ -40,10 +39,12 @@ pub struct State {
 
     pub existing_lockfile: LockFile,
     pub new_lockfile: LockFile,
+
+    pub existing: HashMap<String, ExistingAsset>,
 }
 
 impl State {
-    pub async fn new(args: Args, config: &Config) -> anyhow::Result<Self> {
+    pub async fn new(args: Args, config: Config) -> anyhow::Result<Self> {
         let api_key = get_api_key(args.api_key)?;
 
         let creator: AssetCreator = match config.creator.creator_type {
@@ -90,6 +91,8 @@ impl State {
 
         let new_lockfile: LockFile = Default::default();
 
+        let manual = config.existing.unwrap_or_default();
+
         Ok(Self {
             asset_dir,
             write_dir,
@@ -101,6 +104,7 @@ impl State {
             font_db,
             existing_lockfile,
             new_lockfile,
+            existing: manual,
         })
     }
 }


### PR DESCRIPTION
Some users may be using public assets which they do not want to reupload. This adds support for defining a hashmap in the configuration of file paths to asset IDs, which will then be inserted into the output just like any other file.