### PR TITLE
Ensure CI fails on lint/format warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     lint:
         name: Rustfmt & Clippy
         runs-on: ubuntu-latest
+        env:
+          RUSTFLAGS: "-Dwarnings"
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, the CI workflow will pass even if there are clippy warnings - this change ensures an error will be thrown for any warnings.