### PR TITLE
Make codegen only generate one output file

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,3 +1,5 @@
+use crate::commands::sync::config::CodegenLanguage;
+
 use super::sync::config::{CodegenConfig, CodegenStyle, Creator, CreatorType, SyncConfig};
 use anyhow::Context;
 use console::style;
@@ -52,11 +54,13 @@ pub async fn init() -> anyhow::Result<()> {
         .prompt_skippable()
         .unwrap_or_else(|_| exit(1));
 
-    let typescript = Confirm::new("TypeScript support")
-        .with_help_message("Generate TypeScript definition files.")
-        .with_default(false)
-        .prompt()
-        .unwrap_or_else(|_| exit(1));
+    let codegen_language = Select::new(
+        "Language",
+        vec![CodegenLanguage::Luau, CodegenLanguage::TypeScript],
+    )
+    .with_help_message("The language to generate code in.")
+    .prompt()
+    .unwrap_or_else(|_| exit(1));
 
     let codegen_style = Select::new("Style", vec![CodegenStyle::Flat, CodegenStyle::Nested])
         .with_help_message("The style to use for generated code.")
@@ -76,7 +80,7 @@ pub async fn init() -> anyhow::Result<()> {
         creator: Creator { creator_type, id },
         codegen: CodegenConfig {
             output_name,
-            typescript: Some(typescript),
+            language: Some(codegen_language),
             style: Some(codegen_style),
             strip_extension: Some(strip_extension),
         },

--- a/src/commands/sync/codegen/ast.rs
+++ b/src/commands/sync/codegen/ast.rs
@@ -97,7 +97,7 @@ impl AstFormat for ReturnStatement {
                 write!(output, "return ")
             }
             AstTarget::Typescript { output_dir } => {
-                write!(output, "declare const {output_dir}: ")
+                write!(output, "const {output_dir} = ")
             }
         }?;
 
@@ -148,7 +148,7 @@ impl AstFormat for Table {
     fn fmt_ast(&self, output: &mut AstStream<'_, '_>) -> fmt::Result {
         let typescript = matches!(output.target, AstTarget::Typescript { .. });
         let (assignment, ending) = if typescript {
-            (": ", ";")
+            (": ", ",")
         } else {
             (" = ", ",")
         };

--- a/src/commands/sync/codegen/mod.rs
+++ b/src/commands/sync/codegen/mod.rs
@@ -74,10 +74,10 @@ mod tests {
         let lockfile = test_assets();
 
         let ts = super::flat::generate_ts(&lockfile, "assets", "assets", false).unwrap();
-        assert_eq!(ts, "const assets = {\n\t\"/bar/baz.png\": \"rbxasset://.asphalt/bar/baz.png\";\n\t\"/foo.png\": \"rbxassetid://1\";\n};\nexport = assets;\n");
+        assert_eq!(ts, "const assets = {\n\t\"/bar/baz.png\": \"rbxasset://.asphalt/bar/baz.png\",\n\t\"/foo.png\": \"rbxassetid://1\",\n};\nexport = assets;\n");
 
         let ts = super::flat::generate_ts(&lockfile, "assets", "assets", true).unwrap();
-        assert_eq!(ts, "const assets = {\n\t\"/bar/baz\": \"rbxasset://.asphalt/bar/baz.png\";\n\t\"/foo\": \"rbxassetid://1\";\n};\nexport = assets;\n");
+        assert_eq!(ts, "const assets = {\n\t\"/bar/baz\": \"rbxasset://.asphalt/bar/baz.png\",\n\t\"/foo\": \"rbxassetid://1\",\n};\nexport = assets;\n");
     }
 
     #[test]
@@ -104,13 +104,13 @@ mod tests {
         let ts = super::nested::generate_ts(&lockfile, "assets", "assets", false).unwrap();
         assert_eq!(
             ts,
-            "const assets = {\n\tbar: {\n\t\t\"baz.png\": \"rbxasset://.asphalt/bar/baz.png\";\n\t};\n\t\"foo.png\": \"rbxassetid://1\";\n};\nexport = assets;\n"
+            "const assets = {\n\tbar: {\n\t\t\"baz.png\": \"rbxasset://.asphalt/bar/baz.png\",\n\t};\n\t\"foo.png\": \"rbxassetid://1\",\n};\nexport = assets;\n"
         );
 
         let ts = super::nested::generate_ts(&lockfile, "assets", "assets", true).unwrap();
         assert_eq!(
             ts,
-            "const assets = {\n\tbar: {\n\t\tbaz: \"rbxasset://.asphalt/bar/baz.png\";\n\t};\n\tfoo: \"rbxassetid://1\";\n};\nexport = assets;\n"
+            "const assets = {\n\tbar: {\n\t\tbaz: \"rbxasset://.asphalt/bar/baz.png\",\n\t};\n\tfoo: \"rbxassetid://1\",\n};\nexport = assets;\n"
         );
     }
 }

--- a/src/commands/sync/config.rs
+++ b/src/commands/sync/config.rs
@@ -23,6 +23,31 @@ impl Display for CodegenStyle {
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CodegenLanguage {
+    Luau,
+    TypeScript,
+}
+
+impl Display for CodegenLanguage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CodegenLanguage::Luau => write!(f, "Luau"),
+            CodegenLanguage::TypeScript => write!(f, "TypeScript"),
+        }
+    }
+}
+
+impl CodegenLanguage {
+    pub fn extension(&self) -> &'static str {
+        match self {
+            CodegenLanguage::Luau => "luau",
+            CodegenLanguage::TypeScript => "ts",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum CreatorType {
     User,
@@ -53,7 +78,7 @@ pub struct ExistingAsset {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CodegenConfig {
     pub output_name: Option<String>,
-    pub typescript: Option<bool>,
+    pub language: Option<CodegenLanguage>,
     pub style: Option<CodegenStyle>,
     pub strip_extension: Option<bool>,
 }

--- a/src/commands/sync/state.rs
+++ b/src/commands/sync/state.rs
@@ -1,4 +1,4 @@
-use super::config::{CodegenStyle, CreatorType, ExistingAsset, SyncConfig};
+use super::config::{CodegenLanguage, CodegenStyle, CreatorType, ExistingAsset, SyncConfig};
 use crate::{
     cli::{SyncArgs, SyncTarget},
     LockFile,
@@ -53,7 +53,7 @@ pub struct SyncState {
 
     pub creator: AssetCreator,
 
-    pub typescript: bool,
+    pub language: CodegenLanguage,
     pub output_name: String,
     pub style: CodegenStyle,
     pub strip_extension: bool,
@@ -101,7 +101,7 @@ impl SyncState {
             .unwrap_or(&"assets".to_string())
             .to_string();
 
-        let typescript = config.codegen.typescript.unwrap_or(false);
+        let language = config.codegen.language.unwrap_or(CodegenLanguage::Luau);
         let style = config.codegen.style.unwrap_or(CodegenStyle::Flat);
 
         let strip_extension = config.codegen.strip_extension.unwrap_or(false);
@@ -126,7 +126,7 @@ impl SyncState {
             exclude_assets_matcher,
             api_key,
             creator,
-            typescript,
+            language,
             output_name,
             style,
             strip_extension,


### PR DESCRIPTION
Due to the AST changes merged in #76, the code generation for TypeScript now fills in the asset ID into the declaration file's type. I think that it makes most sense to, from this point forward, only generate one file.

I've went ahead and removed the `typescript` `[codegen]` option in the config, and replaced it with `language`, valid values of which are currently `luau` (default) and `typescript`. I probably didn't need to do this, but it gives us more flexibility to support more languages in the future, should users want them... even if it is unlikely.

The generated TypeScript's file's extension is now `.ts` instead of `.d.ts`, and it exports a variable with the assets, rather than a type.

This is a breaking change. TypeScript users will need to update their configuration with a one-line change, and they will want to delete the `.luau` file, as it would be stale going forward. They might also need to update their linter and/or formatter ignore files, if applicable.
