### PR TITLE
Fix alpha bleed

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -132,7 +132,7 @@ impl Asset {
 
         if let AssetKind::Decal(_) = &kind {
             let mut image: DynamicImage = image::load_from_memory(&data)?;
-            alpha_bleed(&mut image);
+            alpha_bleed(&mut image, 1);
 
             let format = ImageFormat::from_extension(ext)
                 .context("Failed to get image format from extension")?;

--- a/src/util/alpha_bleed.rs
+++ b/src/util/alpha_bleed.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use bit_vec::BitVec;
 use image::{DynamicImage, GenericImage, GenericImageView, Rgba};
 
-pub(crate) fn alpha_bleed(img: &mut DynamicImage) {
+pub(crate) fn alpha_bleed(img: &mut DynamicImage, thickness: usize) {
     let (w, h) = img.dimensions();
 
     // Tells whether a given position has been touched by the bleeding algorithm
@@ -71,38 +71,54 @@ pub(crate) fn alpha_bleed(img: &mut DynamicImage) {
         }
     }
 
-    while let Some((x, y)) = to_visit.pop_front() {
-        // Compute the average color from all surrounding pixels that are
-        // eligible to be sampled from.
-        let mut new_color = (0, 0, 0);
-        let mut contributing = 0;
+    for _ in 0..thickness {
+        let queue_length = to_visit.len();
+        if queue_length == 0 {
+            break;
+        }
 
-        for (x_source, y_source) in adjacent_positions(x, y) {
-            if can_be_sampled.get(x_source, y_source) {
-                let source = img.get_pixel(x_source, y_source);
+        let mut mutated_coords: Vec<(u32, u32)> = vec![(0, 0); queue_length];
+        for _ in 0..queue_length {
+            if let Some((x, y)) = to_visit.pop_front() {
+                // Compute the average color from all surrounding pixels that are
+                // eligible to be sampled from.
+                let mut new_color = (0, 0, 0);
+                let mut contributing = 0;
 
-                contributing += 1;
-                new_color.0 += source[0] as u16;
-                new_color.1 += source[1] as u16;
-                new_color.2 += source[2] as u16;
-            } else if !visited.get(x_source, y_source) {
-                visited.set(x_source, y_source);
-                to_visit.push_back((x_source, y_source));
+                for (x_source, y_source) in adjacent_positions(x, y) {
+                    if can_be_sampled.get(x_source, y_source) {
+                        let source = img.get_pixel(x_source, y_source);
+
+                        contributing += 1;
+                        new_color.0 += source[0] as u16;
+                        new_color.1 += source[1] as u16;
+                        new_color.2 += source[2] as u16;
+                    } else if !visited.get(x_source, y_source) {
+                        visited.set(x_source, y_source);
+                        to_visit.push_back((x_source, y_source));
+                    }
+                }
+
+                let denominator = u16::max(1, contributing);
+                let pixel = Rgba([
+                    (new_color.0 / denominator) as u8,
+                    (new_color.1 / denominator) as u8,
+                    (new_color.2 / denominator) as u8,
+                    0,
+                ]);
+
+                img.put_pixel(x, y, pixel);
+                mutated_coords.push((x, y));
             }
         }
 
-        let pixel = Rgba([
-            (new_color.0 / contributing) as u8,
-            (new_color.1 / contributing) as u8,
-            (new_color.2 / contributing) as u8,
-            0,
-        ]);
-
-        img.put_pixel(x, y, pixel);
-
-        // Now that we've bled this pixel, it's eligible to be sampled from for
-        // future iterations.
-        can_be_sampled.set(x, y);
+        for _ in 0..queue_length {
+            if let Some((x, y)) = mutated_coords.pop() {
+                // Now that we've bled this pixel, it's eligible to be sampled from for
+                // future iterations.
+                can_be_sampled.set(x, y);
+            }
+        }
     }
 }
 

--- a/src/util/alpha_bleed.rs
+++ b/src/util/alpha_bleed.rs
@@ -68,6 +68,8 @@ pub(crate) fn alpha_bleed(img: &mut DynamicImage, thickness: usize) {
                 visited.set(x, y);
                 to_visit.push_back((x, y));
             }
+
+            img.put_pixel(x, y, Rgba([0, 0, 0, 0]));
         }
     }
 


### PR DESCRIPTION
This PR makes a couple of fixes / adjustments to the alpha bleed algorithm.

1. It only bleeds one pixel now. See this [README](https://github.com/EgoMoose/alpha-bleed/blob/main/README.md) for why.
2. Fully transparent pixels that are not bled into are converted to pure black for better encoding.
3. Fixes a mistake in the algorithm where pixels could sample neighbors from the same queue cycle.

The first pass iterates over pixels left-to-right, top-to-bottom so this effect naturally impacts pixels that come further along in the iteration (right and bottom). However, due to the order of the neighbor offsets this effect is somewhat muddied. Regardless, pixels should not be sampling their bled neighbors from the same cycle.

Given an input image:
![tree](https://github.com/user-attachments/assets/05152ece-c1f6-47a8-925b-25c019adba6a)

The results go from looking like this (everything fully opaque):
![image](https://github.com/user-attachments/assets/f6f7df8e-c2a5-45b3-8895-51f70c5e2142)

To this:
![image](https://github.com/user-attachments/assets/efd832ac-c90b-4760-a795-d73776455ba1)
