### PR TITLE
Bleed entire image

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -132,7 +132,7 @@ impl Asset {
 
         if let AssetKind::Decal(_) = &kind {
             let mut image: DynamicImage = image::load_from_memory(&data)?;
-            alpha_bleed(&mut image, 1);
+            alpha_bleed(&mut image);
 
             let format = ImageFormat::from_extension(ext)
                 .context("Failed to get image format from extension")?;

--- a/src/util/alpha_bleed.rs
+++ b/src/util/alpha_bleed.rs
@@ -68,8 +68,6 @@ pub(crate) fn alpha_bleed(img: &mut DynamicImage) {
                 visited.set(x, y);
                 to_visit.push_back((x, y));
             }
-
-            img.put_pixel(x, y, Rgba([0, 0, 0, 0]));
         }
     }
 

--- a/src/util/alpha_bleed.rs
+++ b/src/util/alpha_bleed.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use bit_vec::BitVec;
 use image::{DynamicImage, GenericImage, GenericImageView, Rgba};
 
-pub(crate) fn alpha_bleed(img: &mut DynamicImage, thickness: usize) {
+pub(crate) fn alpha_bleed(img: &mut DynamicImage) {
     let (w, h) = img.dimensions();
 
     // Tells whether a given position has been touched by the bleeding algorithm
@@ -73,7 +73,7 @@ pub(crate) fn alpha_bleed(img: &mut DynamicImage, thickness: usize) {
         }
     }
 
-    for _ in 0..thickness {
+    loop {
         let queue_length = to_visit.len();
         if queue_length == 0 {
             break;


### PR DESCRIPTION
Hi again, very sorry I didn't get this in with the last PR, but I quite literally just figured out this was an issue independantly 10ish minutes ago.

Long story short I was wrong about only needing to bleed one pixel. This is only applicable when the image is being upscaled, not when it's being down-scaled.

If you want more info on how / why I came to this conclusion you can read the last couple responses in this devforum post.
https://devforum.roblox.com/t/photobooth-plugin/3401720/80