### PR TITLE
Use alternative asset API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "roblox_install",
  "serde",
  "serde-xml-rs",
+ "serde_json",
  "tokio",
  "toml",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ resvg = "0.45.0"
 roblox_install = "1.0.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde-xml-rs = "0.6.0"
+serde_json = "1.0.140"
 tokio = { version = "1.44.1", features = ["full"] }
 toml = "0.8.20"
 walkdir = "2.5.0"

--- a/src/sync/backend/cloud.rs
+++ b/src/sync/backend/cloud.rs
@@ -36,6 +36,8 @@ impl SyncBackend for CloudBackend {
                 upload_cloud(
                     state.client.clone(),
                     asset,
+                    state.auth.cookie.clone().unwrap(),
+                    state.csrf.read().await.as_ref().cloned(),
                     state.auth.api_key.clone(),
                     &state.config.creator,
                 )

--- a/src/upload_command.rs
+++ b/src/upload_command.rs
@@ -30,15 +30,15 @@ pub async fn upload(args: UploadArgs) -> anyhow::Result<()> {
 
     let client = reqwest::Client::new();
 
+    let Some(cookie) = auth.cookie.clone() else {
+        bail!("Cookie required for uploading assets");
+    };
+
     let asset_id = match asset.kind {
         AssetKind::Decal(_) | AssetKind::Audio(_) | AssetKind::Model(ModelKind::Model) => {
-            upload_cloud(client, &asset, auth.api_key, &creator).await?
+            upload_cloud(client, &asset, cookie, None, auth.api_key, &creator).await?
         }
         AssetKind::Model(ModelKind::Animation(_)) => {
-            let Some(cookie) = auth.cookie.clone() else {
-                bail!("Cookie required for uploading animations")
-            };
-
             upload_animation(client, &asset, cookie, None, &creator)
                 .await?
                 .asset_id


### PR DESCRIPTION
Closes #104 

Moves the logic for retrieving the image ID from assetdelivery over to an alternative endpoint. The assetdelivery endpoint no longer provided the data we needed.

The old get_image_id function used the assetdelivery API and parsed the returned XML with serde_xml_rs; data models have been updated and parsing has been adjusted to reflect the JSON structure returned by the alternative API.