### PR TITLE
Fix asset delivery authentication and error handling

### DIFF
--- a/src/sync/backend/cloud.rs
+++ b/src/sync/backend/cloud.rs
@@ -51,7 +51,7 @@ impl SyncBackend for CloudBackend {
                     state.client.clone(),
                     asset,
                     cookie,
-                    Some(state.csrf.read().await.as_ref().unwrap().clone()),
+                    state.csrf.read().await.clone(),
                     &state.config.creator,
                 )
                 .await?;

--- a/src/sync/backend/cloud.rs
+++ b/src/sync/backend/cloud.rs
@@ -38,6 +38,7 @@ impl SyncBackend for CloudBackend {
                     asset,
                     state.auth.api_key.clone(),
                     &state.config.creator,
+                    state.auth.cookie.clone(), // Added cookie parameter
                 )
                 .await?
             }

--- a/src/sync/backend/cloud.rs
+++ b/src/sync/backend/cloud.rs
@@ -38,7 +38,7 @@ impl SyncBackend for CloudBackend {
                     asset,
                     state.auth.api_key.clone(),
                     &state.config.creator,
-                    state.auth.cookie.clone(), // Added cookie parameter
+                    state.auth.cookie.clone(),
                 )
                 .await?
             }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -115,15 +115,12 @@ async fn get_image_id(
     let url = format!("https://assetdelivery.roblox.com/v1/asset?id={}", asset_id);
 
     let mut request = client.get(&url);
-    
+
     if let Some(cookie) = cookie {
         request = request.header("Cookie", cookie);
     }
 
-    let response = request
-        .send()
-        .await
-        .context("Failed to get image ID")?;
+    let response = request.send().await.context("Failed to get image ID")?;
 
     let body = response.text().await?;
     let roblox: Roblox = serde_xml_rs::from_str(&body)?;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -23,7 +23,7 @@ pub async fn upload_cloud(
     asset: &Asset,
     api_key: String,
     creator: &Creator,
-    cookie: Option<String>, // New parameter
+    cookie: Option<String>,
 ) -> anyhow::Result<u64> {
     let params = CreateAssetParamsWithContents {
         contents: &asset.data,

--- a/src/upload_command.rs
+++ b/src/upload_command.rs
@@ -32,7 +32,7 @@ pub async fn upload(args: UploadArgs) -> anyhow::Result<()> {
 
     let asset_id = match asset.kind {
         AssetKind::Decal(_) | AssetKind::Audio(_) | AssetKind::Model(ModelKind::Model) => {
-            upload_cloud(client, &asset, auth.api_key, &creator).await?
+            upload_cloud(client, &asset, auth.api_key, &creator, auth.cookie.clone()).await?
         }
         AssetKind::Model(ModelKind::Animation(_)) => {
             let Some(cookie) = auth.cookie.clone() else {


### PR DESCRIPTION
# Changes:
- Add ROBLOSECURITY cookie propagation to asset delivery requests
- Improve server error handling with retry logic for 5xx/429 responses
- Maintain XML response parsing while adding cookie authentication
- Add fallback ID extraction when XML parsing succeeds but ID format changes
- Update upload_cloud calls to pass required cookie parameter

# File changes:
upload_command.rs:
- Pass `auth.cookie.clone()` as an extra argument to `upload_cloud`.

upload.rs:
- Add a new cookie parameter to `upload_cloud` and propagate it to `get_image_id`.
- In `get_image_id`, add the "Cookie" header when a cookie is provided.
- Update XML parsing to extract the asset ID from the `<url>` tag.

cloud.rs:
- Pass `state.auth.cookie.clone()` as an extra argument to `upload_cloud`.

# Reason:
Before, when uploading an asset that had been sent repeatedly with Asphalt, Roblox would sometimes delay its response even though the asset was successfully uploaded. This change fixes that by propagating the ROBLOSECURITY cookie throughout the upload chain and updating the XML parsing logic to reliably extract the asset ID.

# Error that was occuring before these changes:
```
[WARN  asphalt::sync::perform] Failed to sync asset input\Atlantic Shark Revolver.png: Syntax: 1:1 Unexpected characters outside the root element: {
```

# Testing
I have tested this with my big project Assets that contain different image types and everything went fine.