### PR TITLE
Use file hashes as keys instead of file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,67 +1,63 @@
 name: CI
 
-on:
-    push:
-    pull_request:
-        branches:
-            - main
+on: push
 
 jobs:
-    build:
-        name: Build and Test
-        runs-on: ${{ matrix.os }}
+  build:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
 
-        strategy:
-            matrix:
-                os: [ubuntu-latest, windows-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  submodules: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
 
-            - name: Install Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  override: true
-                  profile: minimal
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
 
-            - name: Rust cache
-              uses: Swatinem/rust-cache@v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
-            - name: Build
-              run: cargo build --locked --verbose
+      - name: Build
+        run: cargo build --locked --verbose
 
-            - name: Test
-              run: cargo test --locked --verbose
+      - name: Test
+        run: cargo test --locked --verbose
 
-            - name: Machete
-              uses: bnjbvr/cargo-machete@main
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
 
-    lint:
-        name: Rustfmt & Clippy
-        runs-on: ubuntu-latest
-        env:
-          RUSTFLAGS: "-Dwarnings"
+  lint:
+    name: Rustfmt & Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
 
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  submodules: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
 
-            - name: Install Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  override: true
-                  components: rustfmt, clippy
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
 
-            - name: Rust cache
-              uses: Swatinem/rust-cache@v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
-            - name: Rustfmt
-              run: cargo fmt -- --check
+      - name: Rustfmt
+        run: cargo fmt -- --check
 
-            - name: Clippy
-              run: cargo clippy
+      - name: Clippy
+        run: cargo clippy

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,8 +46,12 @@ pub struct SyncArgs {
     pub target: SyncTarget,
 
     /// Skip asset syncing and only display what assets will be synced.
-    #[arg(long, action)]
+    #[arg(long)]
     pub dry_run: bool,
+
+    /// Suppress warnings of duplicate assets. This does not disable the total duplicate count warning.
+    #[arg(long, default_value_t = false)]
+    pub suppress_duplicate_warnings: bool,
 }
 
 #[derive(Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,9 +20,9 @@ pub enum Commands {
     /// Uploads a single asset and returns the asset ID.
     Upload(UploadArgs),
 
-    /// Migrates a lockfile from pre-1.0 to 1.0. You can only run this once, and it will overwrite the existing lockfile.
-    /// Keep in mind that because pre-1.0 did not support multiple inputs, you'll need to provide a default input name.
-    /// The migration entails hashing your files again and updating the lockfile with the new hashes.
+    /// Migrates a lockfile to the latest version. You can only run this once per upgrade, and it will overwrite the existing lockfile.
+    /// Keep in mind that because pre-1.0 did not support multiple inputs, you'll need to provide a default input name for that migration.
+    /// The pre-1.0 migration entails hashing your files again and updating the lockfile with the new hashes.
     /// We basically pretend nothing has changed, so your assets don't get reuploaded.
     MigrateLockfile(MigrateLockfileArgs),
 }
@@ -79,6 +79,6 @@ pub struct UploadArgs {
 
 #[derive(Args)]
 pub struct MigrateLockfileArgs {
-    /// The default input name to use.
-    pub input_name: String,
+    /// The default input name to use. Only applies when upgrading from V0 to V1.
+    pub input_name: Option<String>,
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,39 +1,56 @@
-use anyhow::bail;
+use anyhow::{Context, bail};
+use blake3::Hasher;
 use fs_err::tokio as fs;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct LockfileEntry {
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct OldLockfileEntry {
     pub hash: String,
     pub asset_id: u64,
 }
 
-pub const CURRENT_VERSION: u32 = 1;
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LockfileEntry {
+    pub asset_id: u64,
+}
+
 pub const FILE_NAME: &str = "asphalt.lock.toml";
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LockfileV0 {
+    entries: BTreeMap<PathBuf, OldLockfileEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LockfileV1 {
+    version: u32,
+    inputs: BTreeMap<String, BTreeMap<PathBuf, OldLockfileEntry>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LockfileV2 {
+    version: u32,
+    inputs: BTreeMap<String, BTreeMap<String, LockfileEntry>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Lockfile {
-    V0 {
-        entries: BTreeMap<String, LockfileEntry>,
-    },
-    V1 {
-        version: u32,
-        inputs: BTreeMap<String, BTreeMap<String, LockfileEntry>>,
-    },
-    V2 {
-        version: u32,
-        inputs: BTreeMap<String, BTreeMap<String, LockfileEntry>>,
-    },
+    V0(LockfileV0),
+    V1(LockfileV1),
+    V2(LockfileV2),
 }
 
 impl Default for Lockfile {
     fn default() -> Self {
-        Lockfile::V1 {
-            version: CURRENT_VERSION,
+        Lockfile::V2(LockfileV2 {
+            version: 2,
             inputs: BTreeMap::new(),
-        }
+        })
     }
 }
 
@@ -51,20 +68,21 @@ impl Lockfile {
 
     pub fn get(&self, input_name: &str, hash: &str) -> Option<&LockfileEntry> {
         match self {
-            Lockfile::V0 { .. } => unreachable!(),
-            Lockfile::V1 { .. } => unreachable!(),
-            Lockfile::V2 { inputs, .. } => {
-                inputs.get(input_name).and_then(|assets| assets.get(hash))
-            }
+            Lockfile::V0(_) => unreachable!(),
+            Lockfile::V1(_) => unreachable!(),
+            Lockfile::V2(lockfile) => lockfile
+                .inputs
+                .get(input_name)
+                .and_then(|assets| assets.get(hash)),
         }
     }
 
     pub fn insert(&mut self, input_name: &str, hash: &str, entry: LockfileEntry) {
         match self {
-            Lockfile::V0 { .. } => unreachable!(),
-            Lockfile::V1 { .. } => unreachable!(),
-            Lockfile::V2 { inputs, .. } => {
-                let input_map = inputs.entry(input_name.to_string()).or_default();
+            Lockfile::V0(_) => unreachable!(),
+            Lockfile::V1(_) => unreachable!(),
+            Lockfile::V2(lockfile) => {
+                let input_map = lockfile.inputs.entry(input_name.to_string()).or_default();
                 input_map.insert(hash.to_string(), entry);
             }
         }
@@ -72,13 +90,82 @@ impl Lockfile {
 
     pub async fn write(&self, filename: Option<&Path>) -> anyhow::Result<()> {
         match self {
-            Lockfile::V0 { .. } => unreachable!(),
-            Lockfile::V1 { .. } => unreachable!(),
-            Lockfile::V2 { .. } => {
+            Lockfile::V0(_) => unreachable!(),
+            Lockfile::V1(_) => unreachable!(),
+            Lockfile::V2(_) => {
                 let content = toml::to_string(self)?;
                 fs::write(filename.unwrap_or(Path::new(FILE_NAME)), content).await?;
                 Ok(())
             }
         }
     }
+
+    pub async fn migrate(&mut self, input_name: Option<String>) -> anyhow::Result<()> {
+        *self = match (&self, input_name) {
+            (Lockfile::V0(lockfile), Some(input_name)) => {
+                migrate_from_v0(lockfile, &input_name).await?
+            }
+            (Lockfile::V0(_), None) => {
+                bail!("An input name must be passed in order to migrate from v0 to v1")
+            }
+            (Lockfile::V1(lockfile), _) => migrate_from_v1(lockfile),
+            (Lockfile::V2(_), _) => bail!("Your lockfile is already up to date"),
+        };
+
+        Ok(())
+    }
+
+    pub fn is_up_to_date(&self) -> bool {
+        match self {
+            Lockfile::V0(_) => false,
+            Lockfile::V1(_) => false,
+            Lockfile::V2(_) => true,
+        }
+    }
+}
+
+fn migrate_from_v1(lockfile: &LockfileV1) -> Lockfile {
+    let mut new_lockfile = Lockfile::default();
+
+    for (input_name, entries) in &lockfile.inputs {
+        for entry in entries.values() {
+            new_lockfile.insert(
+                input_name,
+                &entry.hash,
+                LockfileEntry {
+                    asset_id: entry.asset_id,
+                },
+            )
+        }
+    }
+
+    new_lockfile
+}
+
+async fn migrate_from_v0(lockfile: &LockfileV0, input_name: &str) -> anyhow::Result<Lockfile> {
+    let mut new_lockfile = Lockfile::default();
+
+    for (path, entry) in &lockfile.entries {
+        let new_hash = read_and_hash(path)
+            .await
+            .context(format!("Failed to hash {}", path.display()))?;
+
+        new_lockfile.insert(
+            input_name,
+            &new_hash,
+            LockfileEntry {
+                asset_id: entry.asset_id,
+            },
+        )
+    }
+
+    Ok(new_lockfile)
+}
+
+async fn read_and_hash(path: &Path) -> anyhow::Result<String> {
+    let file = fs::read(path).await?;
+
+    let mut hasher = Hasher::new();
+    hasher.update(&file);
+    Ok(hasher.finalize().to_string())
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -9,13 +9,13 @@ use std::{
 
 pub const FILE_NAME: &str = "asphalt.lock.toml";
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Lockfile {
     version: u32,
     inputs: BTreeMap<String, BTreeMap<String, LockfileEntry>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LockfileEntry {
     pub asset_id: u64,
 }
@@ -48,24 +48,24 @@ impl Lockfile {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OldLockfileEntry {
     pub hash: String,
     pub asset_id: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LockfileV0 {
     entries: BTreeMap<PathBuf, OldLockfileEntry>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LockfileV1 {
     version: u32,
     inputs: BTreeMap<String, BTreeMap<PathBuf, OldLockfileEntry>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RawLockfile {
     V0(LockfileV0),

--- a/src/migrate_lockfile.rs
+++ b/src/migrate_lockfile.rs
@@ -1,9 +1,9 @@
-use crate::{cli::MigrateLockfileArgs, lockfile::Lockfile};
+use crate::{cli::MigrateLockfileArgs, lockfile::RawLockfile};
 
 pub async fn migrate_lockfile(args: MigrateLockfileArgs) -> anyhow::Result<()> {
-    let mut file = Lockfile::read().await?;
-    file.migrate(args.input_name).await?;
-    file.write(None).await?;
+    let file = RawLockfile::read().await?;
+    let migrated = file.migrate(args.input_name.as_deref()).await?;
+    migrated.write(None).await?;
 
     Ok(())
 }

--- a/src/migrate_lockfile.rs
+++ b/src/migrate_lockfile.rs
@@ -1,47 +1,9 @@
-use std::path::Path;
-
-use crate::{
-    cli::MigrateLockfileArgs,
-    lockfile::{Lockfile, LockfileEntry},
-};
-use anyhow::Context;
-use blake3::Hasher;
-use fs_err::tokio as fs;
+use crate::{cli::MigrateLockfileArgs, lockfile::Lockfile};
 
 pub async fn migrate_lockfile(args: MigrateLockfileArgs) -> anyhow::Result<()> {
-    let lockfile = Lockfile::read().await?;
-
-    let entries = lockfile
-        .get_all_if_v0()
-        .context("Your lockfile is already up to date")?;
-
-    let mut new_lockfile = Lockfile::default();
-
-    for (path, entry) in entries {
-        let path = Path::new(&path);
-        let new_hash = read_and_hash(path)
-            .await
-            .context(format!("Failed to hash {}", path.display()))?;
-
-        new_lockfile.insert(
-            &args.input_name,
-            path,
-            LockfileEntry {
-                hash: new_hash,
-                asset_id: entry.asset_id,
-            },
-        );
-    }
-
-    new_lockfile.write(None).await?;
+    let mut file = Lockfile::read().await?;
+    file.migrate(args.input_name).await?;
+    file.write(None).await?;
 
     Ok(())
-}
-
-async fn read_and_hash(path: &Path) -> anyhow::Result<String> {
-    let file = fs::read(path).await?;
-
-    let mut hasher = Hasher::new();
-    hasher.update(&file);
-    Ok(hasher.finalize().to_string())
 }

--- a/src/sync/backend/studio.rs
+++ b/src/sync/backend/studio.rs
@@ -57,21 +57,10 @@ impl SyncBackend for StudioBackend {
         asset: &Asset,
     ) -> anyhow::Result<Option<BackendSyncResult>> {
         if let AssetKind::Model(ModelKind::Animation(_)) = asset.kind {
-            let existing_id = state
-                .existing_lockfile
-                .get(&input_name, &asset.path)
-                .and_then(|entry| {
-                    if entry.hash == asset.hash {
-                        Some(entry.asset_id)
-                    } else {
-                        None
-                    }
-                });
-
-            return match existing_id {
-                Some(id) => Ok(Some(BackendSyncResult::Studio(format!(
+            return match state.existing_lockfile.get(&input_name, &asset.hash) {
+                Some(entry) => Ok(Some(BackendSyncResult::Studio(format!(
                     "rbxassetid://{}",
-                    id
+                    entry.asset_id
                 )))),
                 None => {
                     warn!("Animations cannot be synced in this context");

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     auth::Auth,
     cli::{SyncArgs, SyncTarget},
     config::{Codegen, Config, Input},
-    lockfile::{Lockfile, LockfileEntry},
+    lockfile::{Lockfile, LockfileEntry, RawLockfile},
 };
 use anyhow::{Context, Result, bail};
 use backend::BackendSyncResult;
@@ -69,11 +69,7 @@ pub async fn sync(multi_progress: MultiProgress, args: SyncArgs) -> Result<()> {
     let config = Config::read().await?;
     let codegen_config = config.codegen.clone();
 
-    let lockfile = Lockfile::read().await?;
-
-    if !lockfile.is_up_to_date() {
-        bail!("Your lockfile is out of date, please run asphalt migrate-lockfile")
-    }
+    let lockfile = RawLockfile::read().await?.into_lockfile()?;
 
     let key_required = matches!(args.target, SyncTarget::Cloud) && !args.dry_run;
     let auth = Auth::new(args.api_key.clone(), key_required)?;

--- a/src/sync/walk.rs
+++ b/src/sync/walk.rs
@@ -48,12 +48,13 @@ pub async fn walk(
             input_name.clone(),
             path.clone(),
             &mut seen_hashes,
-            &mut num_dupes,
         )
         .await
         {
             Ok(result) => res.push(result),
             Err(WalkError::DuplicateAsset(original_path)) => {
+                num_dupes += 1;
+
                 if !state.args.suppress_duplicate_warnings {
                     warn!(
                         "Skipping duplicate file {} (original at {})",
@@ -93,7 +94,6 @@ async fn walk_file(
     input_name: String,
     path: PathBuf,
     seen_hashes: &mut HashMap<String, PathBuf>,
-    num_dupes: &mut u32,
 ) -> anyhow::Result<WalkResult, WalkError> {
     let data = match fs::read(&path).await {
         Ok(it) => it,
@@ -106,7 +106,6 @@ async fn walk_file(
 
     let seen = seen_hashes.get(&asset.hash);
     if let Some(seen_path) = seen {
-        *num_dupes += 1;
         return Err(WalkError::DuplicateAsset(seen_path.clone()));
     }
 

--- a/src/sync/walk.rs
+++ b/src/sync/walk.rs
@@ -37,7 +37,7 @@ pub async fn walk(
         .map(|entry| entry.path().to_path_buf())
         .collect::<Vec<_>>();
 
-    let mut res = Vec::new();
+    let mut res = Vec::with_capacity(entries.len());
 
     for path in entries {
         progress_bar.set_message(format!("Reading {}", path.display()));

--- a/src/sync/walk.rs
+++ b/src/sync/walk.rs
@@ -111,9 +111,9 @@ async fn walk_file(
 
     seen_hashes.insert(asset.hash.clone(), path.clone());
 
-    let existing_entry = state.existing_lockfile.get(&input_name, &asset.hash);
+    let entry = state.existing_lockfile.get(&input_name, &asset.hash);
 
-    match (existing_entry, &state.args.target) {
+    match (entry, &state.args.target) {
         (Some(entry), SyncTarget::Cloud) => {
             Ok(WalkResult::Existing((path, asset.hash, entry.clone())))
         }


### PR DESCRIPTION
This changes the lockfile structure to be keyed by file hashes instead of file paths. Users can now freely restructure their assets without reuploads.
Inputs are still saved in the lockfile separately, so moving a file from one input to another, or renaming an input, would still cause a reupload.
