### PR TITLE
Split migrate-lockfile help text into head and body

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,9 @@ pub enum Commands {
     /// Uploads a single asset and returns the asset ID.
     Upload(UploadArgs),
 
-    /// Migrates a lockfile to the latest version. You can only run this once per upgrade, and it will overwrite the existing lockfile.
+    /// Migrates a lockfile to the latest version.
+    ///
+    /// You can only run this once per upgrade, and it will overwrite the existing lockfile.
     /// Keep in mind that because pre-1.0 did not support multiple inputs, you'll need to provide a default input name for that migration.
     /// The pre-1.0 migration entails hashing your files again and updating the lockfile with the new hashes.
     /// We basically pretend nothing has changed, so your assets don't get reuploaded.


### PR DESCRIPTION
The output of `asphalt --help` before this change, with terminal line wrap simulated:
```
Commands:
  sync              Sync assets
  upload            Uploads a single asset and returns the asset ID
  migrate-lockfile  Migrates a lockfile to the latest version. You can only run
this once per upgrade, and it will overwrite the existing lockfile. Keep in mind
 that because pre-1.0 did not support multiple inputs, you'll need to provide a
default input name for that migration. The pre-1.0 migration entails hashing you
r files again and updating the lockfile with the new hashes. We basically preten
d nothing has changed, so your assets don't get reuploaded
  help              Print this message or the help of the given subcommand(s)
```
After:
```
Commands:
  sync              Sync assets
  upload            Uploads a single asset and returns the asset ID
  migrate-lockfile  Migrates a lockfile to the latest version
  help              Print this message or the help of the given subcommand(s)
```
The full text is still shown with `asphalt migrate-lockfile --help`.

My motivation for this change is that I would prefer a short summary of the command in that position rather than its full description.
