### PR TITLE
Support outputting Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ output_path = "src/shared"
     -   The code-generation style to use. Defaults to `flat`, which makes accessing assets feel like writing file paths. You may consider using `nested` if you are not a TypeScript user, however, as Luau does not support template literal types.
 -   `strip_extensions`: boolean (optional)
     -   Whether to strip the file extension. Defaults to `false` for the same reason described above.
+-   `content`: boolean (optional)
+    -   Whether to output `Content` instead of `string`s. Defaults to `false`.
 
 #### Input
 -	`path`: glob

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Codegen {
     pub style: CodegenStyle,
     pub typescript: bool,
     pub strip_extensions: bool,
+    pub content: bool,
 }
 
 #[derive(Debug, Deserialize, Clone, ValueEnum)]

--- a/src/sync/snapshots/asphalt__sync__codegen__tests__luau_codegen.snap
+++ b/src/sync/snapshots/asphalt__sync__codegen__tests__luau_codegen.snap
@@ -10,6 +10,7 @@ local name = {
 		baz = 42,
 		foo = "bar",
 	},
+	waldo = Content.fromUri("garply"),
 }
 
 return name

--- a/src/sync/snapshots/asphalt__sync__codegen__tests__typescript_codegen.snap
+++ b/src/sync/snapshots/asphalt__sync__codegen__tests__typescript_codegen.snap
@@ -10,6 +10,7 @@ declare const name: {
 		baz: number
 		foo: string
 	}
+	waldo: Content
 }
 
 export = name


### PR DESCRIPTION
Adds a `content` setting to enable outputting `Content` instead of `string`s.